### PR TITLE
Fix subscription sync strategy

### DIFF
--- a/dripdrop/apps/admin/app.py
+++ b/dripdrop/apps/admin/app.py
@@ -1,18 +1,71 @@
-from fastapi import FastAPI, Depends, Response, status
+from fastapi import FastAPI, Depends, Response, status, Query
+from pydantic import EmailStr
 
+from dripdrop.apps.music.tasks import music_tasker
+from dripdrop.apps.youtube.tasks import youtube_tasker
+from dripdrop.rq import queue
 from dripdrop.services.cron import cron_service
 
 from .dependencies import get_admin_user
 
 
-app = FastAPI(openapi_tags=["Admin"])
+app = FastAPI(
+    openapi_tags=["Admin"],
+    dependencies=[Depends(get_admin_user)],
+)
 
 
 @app.get(
     "/cron/run",
-    dependencies=[Depends(get_admin_user)],
     responses={status.HTTP_403_FORBIDDEN: {}},
 )
-async def run_cronjobs():
-    await cron_service.async_run_cron_jobs()
+def run_cron_jobs():
+    cron_service.run_cron_jobs()
+    return Response(None, status_code=status.HTTP_200_OK)
+
+
+@app.get("/delete_old_jobs")
+def run_delete_old_jobs():
+    queue.enqueue(music_tasker.delete_old_jobs)
+    return Response(None, status_code=status.HTTP_200_OK)
+
+
+@app.get("/update_subscriptions")
+def run_update_subscriptions(email: EmailStr | None = Query(None)):
+    job = queue.enqueue(youtube_tasker.update_video_categories, args=(False,))
+    if email:
+        queue.enqueue(
+            youtube_tasker.update_user_subscriptions,
+            args=(email,),
+            depends_on=job,
+        )
+    else:
+        queue.enqueue(
+            youtube_tasker.update_subscriptions,
+            depends_on=job,
+        )
+    return Response(None, status_code=status.HTTP_200_OK)
+
+
+@app.get("/delete_old_channels")
+def run_delete_old_channels():
+    queue.enqueue(youtube_tasker.delete_old_channels)
+    return Response(None, status_code=status.HTTP_200_OK)
+
+
+@app.get("/update_channels/meta")
+def run_update_channels_meta():
+    queue.enqueue(youtube_tasker.update_channels_meta)
+    return Response(None, status_code=status.HTTP_200_OK)
+
+
+@app.get("/update_channels/video")
+def run_update_channels_videos():
+    queue.enqueue(youtube_tasker.update_channels_videos)
+    return Response(None, status_code=status.HTTP_200_OK)
+
+
+@app.get("/update_video_categories")
+def run_update_video_categories():
+    queue.enqueue(youtube_tasker.update_video_categories)
     return Response(None, status_code=status.HTTP_200_OK)

--- a/dripdrop/apps/youtube/app.py
+++ b/dripdrop/apps/youtube/app.py
@@ -72,11 +72,9 @@ async def google_oauth2(
                 )
             )
             await session.commit()
-        job = queue.enqueue(
-            youtube_tasker.update_youtube_video_categories, args=(False,)
-        )
+        job = queue.enqueue(youtube_tasker.update_video_categories, args=(False,))
         queue.enqueue(
-            youtube_tasker.update_user_youtube_subscriptions_job,
+            youtube_tasker.update_user_subscriptions,
             args=(user.email,),
             depends_on=job,
         )

--- a/dripdrop/apps/youtube/tasks.py
+++ b/dripdrop/apps/youtube/tasks.py
@@ -1,14 +1,14 @@
 import dateutil.parser
 import traceback
 from datetime import datetime, timedelta
-from sqlalchemy import select, func, delete
+from sqlalchemy import select, func
 
 from dripdrop.database import Session
 from dripdrop.logging import logger
 from dripdrop.services.google_api import google_api_service
 from dripdrop.settings import settings
 from dripdrop.rq import queue
-from dripdrop.utils import worker_task, exception_handler
+from dripdrop.utils import worker_task
 
 from .models import (
     GoogleAccount,
@@ -16,16 +16,13 @@ from .models import (
     YoutubeSubscription,
     YoutubeVideo,
     YoutubeVideoCategory,
+    create_temp_subscriptions_table,
 )
 from .utils import update_google_access_token
 
 
 class YoutubeTasker:
-    def enqueue(self, *args, **kwargs):
-        queue.enqueue(*args, **kwargs, at_front=True)
-
-    @exception_handler
-    def add_update_youtube_subscription(
+    def _add_update_subscription(
         self,
         google_email: str = ...,
         subscription: dict = ...,
@@ -54,9 +51,9 @@ class YoutubeTasker:
                 )
             )
         session.commit()
+        return bool(subscription)
 
-    @exception_handler
-    def add_update_youtube_channel(self, channel: dict = ..., session: Session = ...):
+    def _add_update_channel(self, channel: dict = ..., session: Session = ...):
         channel_id = channel["id"]
         channel_title = channel["snippet"]["title"]
         channel_upload_playlist_id = channel["contentDetails"]["relatedPlaylists"][
@@ -82,9 +79,9 @@ class YoutubeTasker:
                 )
             )
         session.commit()
+        return bool(channel)
 
-    @exception_handler
-    def add_update_youtube_video(self, video: dict = ..., session: Session = ...):
+    def _add_update_video(self, video: dict = ..., session: Session = ...):
         video_id = video["id"]
         video_title = video["snippet"]["title"]
         video_thumbnail = video["snippet"]["thumbnails"]["high"]["url"]
@@ -93,7 +90,7 @@ class YoutubeTasker:
         video_category_id = int(video["snippet"]["categoryId"])
         query = select(YoutubeVideo).where(YoutubeVideo.id == video_id)
         results = session.scalars(query)
-        video: YoutubeVideo = results.first()
+        video = results.first()
         if video:
             video.title = video_title
             video.thumbnail = video_thumbnail
@@ -111,20 +108,20 @@ class YoutubeTasker:
                 )
             )
         session.commit()
+        return bool(video)
 
     @worker_task
-    def update_channels(self, channel_ids: list[int] = ..., session: Session = ...):
+    def _update_channels(self, channel_ids: list[int] = ..., session: Session = ...):
         channels_info = google_api_service.get_channels_info(channel_ids=channel_ids)
         for channel_info in channels_info:
-            self.add_update_youtube_channel(channel=channel_info, session=session)
+            try:
+                self.add_update_channel(channel=channel_info, session=session)
+            except Exception:
+                logger.exception(traceback.format_exc())
 
-    @exception_handler
-    def add_update_youtube_video_category(
-        self, category: dict = ..., session: Session = ...
-    ):
+    def _add_update_video_category(self, category: dict = ..., session: Session = ...):
         category_id = int(category["id"])
         category_title = category["snippet"]["title"]
-        logger.exception(traceback.format_exc())
         query = select(YoutubeVideoCategory).where(
             YoutubeVideoCategory.id == category_id
         )
@@ -135,9 +132,10 @@ class YoutubeTasker:
         else:
             session.add(YoutubeVideoCategory(id=category_id, name=category_title))
         session.commit()
+        return bool(category)
 
     @worker_task
-    def update_youtube_video_categories(self, cron: bool = ..., session: Session = ...):
+    def update_video_categories(self, cron: bool = ..., session: Session = ...):
         if not cron:
             query = select(func.count(YoutubeVideoCategory.id))
             count = session.scalar(query)
@@ -145,12 +143,28 @@ class YoutubeTasker:
                 return
         video_categories = google_api_service.get_video_categories()
         for category in video_categories:
-            self.add_update_youtube_video_category(category=category, session=session)
+            try:
+                self._add_update_video_category(category=category, session=session)
+            except Exception:
+                logger.exception(traceback.format_exc())
 
     @worker_task
-    def update_user_youtube_subscriptions_job(
-        self, user_email: str = ..., session: Session = ...
+    def _delete_subscription(
+        self, subscription_id: str = ..., email: str = ..., session: Session = ...
     ):
+        query = select(YoutubeSubscription).where(
+            YoutubeSubscription.id == subscription_id,
+            YoutubeSubscription.email == email,
+        )
+        results = session.scalars(query)
+        subscription = results.first()
+        if not subscription:
+            raise Exception(f"Subscription ({subscription_id}) not found")
+        session.delete(subscription)
+        session.commit()
+
+    @worker_task
+    def update_user_subscriptions(self, user_email: str = ..., session: Session = ...):
         query = select(GoogleAccount).where(GoogleAccount.user_email == user_email)
         results = session.scalars(query)
         account = results.first()
@@ -162,42 +176,75 @@ class YoutubeTasker:
         if not account.access_token:
             return
 
-        for subscriptions in google_api_service.get_user_subscriptions(
-            access_token=account.access_token
-        ):
-            subscription_channel_ids = [
-                subscription["snippet"]["resourceId"]["channelId"]
-                for subscription in subscriptions
-            ]
-            query = select(YoutubeChannel).where(
-                YoutubeChannel.id.in_(subscription_channel_ids)
-            )
-            results = session.scalars(query)
-            channels: list[YoutubeChannel] = results.all()
-            channel_ids = [channel.id for channel in channels]
-            new_channel_ids = list(
-                filter(
-                    lambda channel_id: channel_id not in channel_ids,
-                    subscription_channel_ids,
+        with create_temp_subscriptions_table(
+            email=account.email, session=session
+        ) as TempSubscription:
+            for subscriptions in google_api_service.get_user_subscriptions(
+                access_token=account.access_token
+            ):
+                subscription_channel_ids = [
+                    subscription["snippet"]["resourceId"]["channelId"]
+                    for subscription in subscriptions
+                ]
+                query = select(YoutubeChannel).where(
+                    YoutubeChannel.id.in_(subscription_channel_ids)
                 )
-            )
-            if len(new_channel_ids) > 0:
-                channels_info = google_api_service.get_channels_info(
-                    channel_ids=new_channel_ids
-                )
-                for channel_info in channels_info:
-                    self.add_update_youtube_channel(
-                        channel=channel_info, session=session
+                results = session.scalars(query)
+                channels = results.all()
+                channel_ids = [channel.id for channel in channels]
+                new_channel_ids = list(
+                    filter(
+                        lambda channel_id: channel_id not in channel_ids,
+                        subscription_channel_ids,
                     )
-            for subscription in subscriptions:
-                self.add_update_youtube_subscription(
-                    google_email=account.email,
-                    subscription=subscription,
-                    session=session,
+                )
+                if len(new_channel_ids) > 0:
+                    channels_info = google_api_service.get_channels_info(
+                        channel_ids=new_channel_ids
+                    )
+                    for channel_info in channels_info:
+                        self._add_update_channel(channel=channel_info, session=session)
+                for subscription in subscriptions:
+                    try:
+                        self._add_update_subscription(
+                            google_email=account.email,
+                            subscription=subscription,
+                            session=session,
+                        )
+                        session.add(TempSubscription(id=subscription["id"]))
+                        session.commit()
+                    except Exception:
+                        logger.exception(traceback.format_exc())
+            subscription_query = (
+                select(YoutubeSubscription)
+                .where(YoutubeSubscription.email == account.email)
+                .subquery()
+            )
+            temp_subscription_query = select(TempSubscription).subquery()
+            query = subscription_query.join(
+                temp_subscription_query,
+                subscription_query.columns.id == temp_subscription_query.columns.id,
+                isouter=True,
+            )
+            stream = session.execute(
+                select(subscription_query.columns.id.label("subscription_id"))
+                .select_from(query)
+                .where(temp_subscription_query.columns.id.is_(None))
+            ).mappings()
+            for row in stream.yield_per(10):
+                queue.enqueue(
+                    self._delete_subscription,
+                    kwargs={
+                        "subscription_id": row.subscription_id,
+                        "email": account.email,
+                    },
+                    at_front=True,
                 )
 
     @worker_task
-    def add_new_channel_videos_job(self, channel_id: str = ..., session: Session = ...):
+    def _add_new_channel_videos_job(
+        self, channel_id: str = ..., session: Session = ...
+    ):
         query = select(YoutubeChannel).where(YoutubeChannel.id == channel_id)
         results = session.scalars(query)
         channel = results.first()
@@ -206,48 +253,46 @@ class YoutubeTasker:
         ):
             new_videos = []
             video_ids = []
-            for uploaded_video in uploaded_playlist_videos:
-                video_published_at = dateutil.parser.parse(
-                    uploaded_video["contentDetails"]["videoPublishedAt"]
-                )
-                uploaded_video["contentDetails"][
-                    "videoPublishedAt"
-                ] = video_published_at
-                video_ids.append(uploaded_video["contentDetails"]["videoId"])
-                if video_published_at > channel.last_videos_updated:
-                    new_videos.append(uploaded_video)
             videos_info = google_api_service.get_videos_info(video_ids=video_ids)
             for video_info in videos_info:
-                self.add_update_youtube_video(video=video_info, session=session)
+                try:
+                    new_video = self.add_update_video(video=video_info, session=session)
+                    if new_video:
+                        new_videos.append(video_info["id"])
+                except Exception:
+                    logger.exception(traceback.format_exc())
             if len(new_videos) < len(uploaded_playlist_videos):
                 break
         channel.last_videos_updated = datetime.now(tz=settings.timezone)
         session.commit()
 
     @worker_task
-    def update_subscribed_channels_videos(self, session: Session = ...):
-        query = select([YoutubeSubscription.channel_id.distinct()])
+    def update_channels_videos(self, session: Session = ...):
+        query = select(YoutubeChannel)
         stream = session.scalars(query)
-        for subscription in stream.yield_per(10):
-            self.enqueue(
-                self.add_new_channel_videos_job,
-                kwargs={"channel_id": subscription.channel_id},
+        for channel in stream.yield_per(10):
+            queue.enqueue(
+                self._add_new_channel_videos_job,
+                kwargs={"channel_id": channel.id},
+                at_front=True,
             )
 
     @worker_task
-    def update_subscribed_channels_meta(self, session: Session = ...):
+    def update_channels_meta(self, session: Session = ...):
         CHANNEL_NUM = 50
         page = 0
         while True:
-            query = select([YoutubeSubscription.channel_id.distinct()]).offset(
-                page * CHANNEL_NUM
-            )
+            query = select(YoutubeChannel).offset(page * CHANNEL_NUM)
             results = session.scalars(query)
-            subscriptions: list[YoutubeSubscription] = results.fetchmany(CHANNEL_NUM)
-            if len(subscriptions) == 0:
+            channels = results.fetchmany(CHANNEL_NUM)
+            if len(channels) == 0:
                 break
-            channel_ids = [subscription.channel_id for subscription in subscriptions]
-            self.enqueue(self.update_channels, kwargs={"channel_ids": channel_ids})
+            channel_ids = [channel.id for channel in channels]
+            queue.enqueue(
+                self._update_channels,
+                kwargs={"channel_ids": channel_ids},
+                at_front=True,
+            )
             page += 1
 
     @worker_task
@@ -255,33 +300,38 @@ class YoutubeTasker:
         query = select(GoogleAccount)
         stream = session.scalars(query)
         for account in stream.yield_per(10):
-            self.enqueue(
-                self.update_user_youtube_subscriptions_job,
+            queue.enqueue(
+                self.update_user_subscriptions,
                 kwargs={"user_email": account.user_email},
+                at_front=True,
             )
 
     @worker_task
-    def delete_channel(self, channel_id: str = ..., session: Session = ...):
+    def _delete_channel(self, channel_id: str = ..., session: Session = ...):
         query = select(YoutubeChannel).where(YoutubeChannel.id == channel_id)
         results = session.scalars(query)
         channel = results.first()
         if not channel:
             raise Exception(f"Channel ({channel_id}) not found")
-        query = delete(YoutubeSubscription).where(
-            YoutubeSubscription.channel_id == channel.id
-        )
-        session.execute(query)
-        session.commit()
         session.delete(channel)
         session.commit()
 
     @worker_task
     def delete_old_channels(self, session: Session = ...):
-        limit = datetime.now(tz=settings.timezone) - timedelta(days=7)
-        query = select(YoutubeChannel).where(YoutubeChannel.last_videos_updated < limit)
+        query = (
+            select(YoutubeChannel)
+            .join(
+                YoutubeSubscription,
+                YoutubeChannel.id == YoutubeSubscription.channel_id,
+                isouter=True,
+            )
+            .where(YoutubeSubscription.id.is_(None))
+        )
         stream = session.scalars(query)
         for channel in stream.yield_per(10):
-            self.enqueue(self.delete_channel, kwargs={"channel_id": channel.id})
+            queue.enqueue(
+                self._delete_channel, kwargs={"channel_id": channel.id}, at_front=True
+            )
 
 
 youtube_tasker = YoutubeTasker()

--- a/dripdrop/apps/youtube/videos.py
+++ b/dripdrop/apps/youtube/videos.py
@@ -157,7 +157,7 @@ async def get_youtube_videos(
         queued_only=queued_only,
         offset=(page - 1) * per_page,
         limit=per_page,
-        subscribed_only=channel_id is None,
+        subscribed_only=channel_id is None and not liked_only and not queued_only,
     )
     if page > total_pages and page != 1:
         raise HTTPException(

--- a/tests/integration/youtube/test_videos.py
+++ b/tests/integration/youtube/test_videos.py
@@ -448,7 +448,6 @@ def test_videos_with_queued_only(
     create_and_login_user,
     create_google_account,
     create_channel,
-    create_subscription,
     create_video_category,
     create_video,
     create_video_queue,
@@ -464,7 +463,6 @@ def test_videos_with_queued_only(
     channel = create_channel(
         id="1", title="channel", thumbnail="thumbnail", upload_playlist_id="1"
     )
-    create_subscription(id="1", channel_id=channel.id, email=google_account.email)
     category = create_video_category(id=1, name="category")
     queued_video = create_video(
         id="1",
@@ -512,7 +510,6 @@ def test_videos_with_queued_only_in_ascending_order_by_created_date(
     create_and_login_user,
     create_google_account,
     create_channel,
-    create_subscription,
     create_video_category,
     create_video,
     create_video_queue,
@@ -528,7 +525,6 @@ def test_videos_with_queued_only_in_ascending_order_by_created_date(
     channel = create_channel(
         id="1", title="channel", thumbnail="thumbnail", upload_playlist_id="1"
     )
-    create_subscription(id="1", channel_id=channel.id, email=google_account.email)
     category = create_video_category(id=1, name="category")
     videos = list(
         map(
@@ -593,7 +589,6 @@ def test_videos_with_liked_only(
     create_and_login_user,
     create_google_account,
     create_channel,
-    create_subscription,
     create_video_category,
     create_video,
     create_video_like,
@@ -609,7 +604,6 @@ def test_videos_with_liked_only(
     channel = create_channel(
         id="1", title="channel", thumbnail="thumbnail", upload_playlist_id="1"
     )
-    create_subscription(id="1", channel_id=channel.id, email=google_account.email)
     category = create_video_category(id=1, name="category")
     liked_video = create_video(
         id="1",
@@ -655,7 +649,6 @@ def test_videos_with_liked_only_in_descending_order_by_created_date(
     create_and_login_user,
     create_google_account,
     create_channel,
-    create_subscription,
     create_video_category,
     create_video,
     create_video_like,
@@ -671,7 +664,6 @@ def test_videos_with_liked_only_in_descending_order_by_created_date(
     channel = create_channel(
         id="1", title="channel", thumbnail="thumbnail", upload_playlist_id="1"
     )
-    create_subscription(id="1", channel_id=channel.id, email=google_account.email)
     category = create_video_category(id=1, name="category")
     videos = list(
         map(


### PR DESCRIPTION
- Use temporary tables to join against current user subscriptions in order to properly remove deleted subscriptions
- Fix delete channel cron to only delete channels with no tied subscriptions
- Update naming of methods in taskers that are private / public
- Fix videos endpoint to ignore only subscribed channels when retrieving liked or queued videos (update tests to reflect change)
- Add additional admin endpoints to trigger specific tasks