### PR TITLE
Add dripdrop display name to SMTP sender address

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
     invidious_api_url: str
     redis_url: str
     secret_key: str
-    smtp_from_email: str = "app@dripdrop.pro"
+    smtp_from_email: str = "dripdrop <app@dripdrop.pro>"
     smtp_host: str = "smtp.protonmail.ch"
     smtp_password: str
     smtp_port: int = 587


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the default `smtp_from_email` setting so outbound mail shows a friendly sender name:

**Before:** `app@dripdrop.pro`  
**After:** `dripdrop <app@dripdrop.pro>`

## Notes

- If `SMTP_FROM_EMAIL` is set in your deployment environment, update it there as well to include the display name (e.g. `dripdrop <app@dripdrop.pro>`).
- Email tasks already pass `settings.smtp_from_email` through to the `From` header unchanged; no other code changes were required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63cbf40d-7a8a-4047-9a72-c8b6a9787b52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63cbf40d-7a8a-4047-9a72-c8b6a9787b52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

