### PR TITLE
Upgrade react-player to v3

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23,7 +23,7 @@
         "react-helmet-async": "^3.0.0",
         "react-hook-form": "^7.43.2",
         "react-icons": "^5.4.0",
-        "react-player": "^2.16.1",
+        "react-player": "^3.4.0",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.0.0"
       },
@@ -816,6 +816,74 @@
         "react": "^18.x || ^19.x"
       }
     },
+    "node_modules/@mux/mux-data-google-ima": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.3.17.tgz",
+      "integrity": "sha512-4wpH6dYybyZhqLn9qGn/+67Z8MZnQRAdqTFEEZw2bx61M9q01uPYYHxd8qwOnYtUGEeafsdTwVHVxKHGD3oc1A==",
+      "license": "MIT",
+      "dependencies": {
+        "mux-embed": "5.18.1"
+      }
+    },
+    "node_modules/@mux/mux-player": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.13.0.tgz",
+      "integrity": "sha512-vh4CIMahUa29gys+mlfsOFKYKAKXxE07jSWk9WZxkdpGBW1fKfCQXlNxBoAIQlPa9Uk4MZuM3HVgqdW6aTuaZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-video": "0.31.0",
+        "@mux/playback-core": "0.35.0",
+        "media-chrome": "~4.19.0",
+        "player.style": "^0.3.0"
+      }
+    },
+    "node_modules/@mux/mux-player-react": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.13.0.tgz",
+      "integrity": "sha512-7IkImo1H3rUYeuWHI/L0L7sGUqBvZCvptx3+4igc+P/V3WgqNFjOyQlcyxzxgXNtNNhGmkn5NaF3TU9DPbOmAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-player": "3.13.0",
+        "@mux/playback-core": "0.35.0",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
+        "react": "^17.0.2 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
+        "react-dom": "^17.0.2 || ^17.0.2-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mux/mux-video": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.31.0.tgz",
+      "integrity": "sha512-DvO2GynIJhPDc0LMuWvC144lCF+E07NI+chrg/vcRQlCf2fPdNNqCSMoaRdWu2S2v/Orsc85giT9K6GRbjbzgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-data-google-ima": "^0.3.4",
+        "@mux/playback-core": "0.35.0",
+        "castable-video": "~1.1.13",
+        "custom-media-element": "~1.4.6",
+        "media-tracks": "~0.3.5"
+      }
+    },
+    "node_modules/@mux/playback-core": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.35.0.tgz",
+      "integrity": "sha512-7Zi1EJ9sQNIUlQVBjJCXV0CB+rUVEsU3vNRElRV4xnD7dbpoioIAhe1SjZNBifjnK5aBKLDwQHypbnL3Cw3a5A==",
+      "license": "MIT",
+      "dependencies": {
+        "hls.js": "~1.6.15",
+        "mux-embed": "^5.16.1"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
@@ -1187,6 +1255,129 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@svta/cml-608": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@svta/cml-608/-/cml-608-1.0.2.tgz",
+      "integrity": "sha512-ZEJ68330gcLKfvVv6Qifr1HR7+GldDUxzkjqSbqRK7jHtHSLSV1JAyDwlYe8+C7ABuY1bp8MpgJ4/Gg+jl+pLQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@svta/cml-cmcd": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@svta/cml-cmcd/-/cml-cmcd-2.3.2.tgz",
+      "integrity": "sha512-SKBBjLmci0WK8HMjuv+36tVIMktonoOoxsXblOFZmB+ePPV2zjRMTD+2ZmE/1VEPJkKHENyhSjSHgJyeOlvZ1A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-structured-field-values": "1.1.3",
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
+    "node_modules/@svta/cml-cmsd": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@svta/cml-cmsd/-/cml-cmsd-1.0.6.tgz",
+      "integrity": "sha512-LUORV6bb0TbU4rSC2HoPqUCix1igLrXkRQXWiIyJo2OMzb14kAK/1jsW0mzY6up6w1GrjKQcjc6OwqJdo/zd/g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-cta": "1.0.6",
+        "@svta/cml-structured-field-values": "1.1.3",
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
+    "node_modules/@svta/cml-cta": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@svta/cml-cta/-/cml-cta-1.0.6.tgz",
+      "integrity": "sha512-l13/4myTX1EbRd38nY8J1umVY5UdR/nZO6CeKqVLXnMMIayg7/fu0TueZckjTA9Loal55MGK1xbHnXVjz7OUUw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-structured-field-values": "1.1.3",
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
+    "node_modules/@svta/cml-dash": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@svta/cml-dash/-/cml-dash-1.0.6.tgz",
+      "integrity": "sha512-4XtHYlPrzL/dRe/8XmRQoLnTo9S86tISgrl67eUqKl5MtNTpZBYTncuPrspslPZPZROBBWNrBuepYfYUtU9CKA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
+    "node_modules/@svta/cml-id3": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@svta/cml-id3/-/cml-id3-1.0.6.tgz",
+      "integrity": "sha512-63j8gkAnPOmOBWlp0hIZPvsIioZttdbg6/TgwITqMYbSLYVJ+6QGa/UtIP0I84NsfstANw6QdCn7i8SS08kn1A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
+    "node_modules/@svta/cml-request": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@svta/cml-request/-/cml-request-1.0.12.tgz",
+      "integrity": "sha512-4sJvnnoNpq58j2mCGP8k+MF6wVy/qa4gbt6kfT1dPIKmn3mPxw+JVfilhcWsUi+peK2yCZxOJJYyHj1cAcQE1w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-cmcd": "2.3.2",
+        "@svta/cml-utils": "1.5.0",
+        "@svta/cml-xml": "1.1.4"
+      }
+    },
+    "node_modules/@svta/cml-structured-field-values": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@svta/cml-structured-field-values/-/cml-structured-field-values-1.1.3.tgz",
+      "integrity": "sha512-XqLzQOTznz6kh/nsSh8dy1kV7GQjL4csG+2U5EvLGhAqNuNUczbVg5EAsDobKDVg8xhdthdXx2UuwM+ZHQCxSg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
+    "node_modules/@svta/cml-utils": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@svta/cml-utils/-/cml-utils-1.5.0.tgz",
+      "integrity": "sha512-JMqclD7Akd+GSJiuaYNUHOP2wNtf/nauKeszlYeivSHfi0Lp3pmSW5PXDvJ2dO4aPmmSOQbF0ztTsW9Vcs2Whw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@svta/cml-xml": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@svta/cml-xml/-/cml-xml-1.1.4.tgz",
+      "integrity": "sha512-jbixqjiJIc16SGxylHwiOzO+DuhkGfuP+fJ9AHeVJKdFDKnabgfCDpnp6dvZpZnjMj4nHvzVtuUV7RISPIwYXw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1223,7 +1414,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1244,6 +1434,16 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@vimeo/player": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@vimeo/player/-/player-2.29.0.tgz",
+      "integrity": "sha512-9JjvjeqUndb9otCCFd0/+2ESsLk7VkDE6sxOBy9iy2ukezuQbplVRi+g9g59yAurKofbmTi/KcKxBGO/22zWRw==",
+      "license": "MIT",
+      "dependencies": {
+        "native-promise-only": "0.8.1",
+        "weakmap-polyfill": "2.0.4"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
@@ -1405,6 +1605,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/bcp-47-match": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -1517,6 +1727,24 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/castable-video": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.1.16.tgz",
+      "integrity": "sha512-wBhe2dZu2afhewL3EaGgVYTyDsa9HvNhY98clMZkNzDrLelOValSrTaoMos9YX7PPBCrgpd1j6YmNyyI2Vbq3w==",
+      "license": "MIT",
+      "dependencies": {
+        "custom-media-element": "~1.4.6"
+      }
+    },
+    "node_modules/ce-la-react": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ce-la-react/-/ce-la-react-0.3.2.tgz",
+      "integrity": "sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "react": ">=17.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1548,6 +1776,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/cloudflare-video-element": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/cloudflare-video-element/-/cloudflare-video-element-1.3.5.tgz",
+      "integrity": "sha512-zj9gjJa6xW8MNrfc4oKuwgGS0njRLpOlQjdifbuNxvy8k4Y3pKCyKCMG2XIsjd2iQGhgjS57b1P5VWdJlxcXBw==",
+      "license": "MIT"
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1556,6 +1790,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/codem-isoboxer": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/codem-isoboxer/-/codem-isoboxer-0.3.10.tgz",
+      "integrity": "sha512-eNk3TRV+xQMJ1PEj0FQGY8KD4m0GPxT487XJ+Iftm7mVa9WpPFDMWqPt+46buiP5j5Wzqe5oMIhqBcAeKfygSA==",
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -1642,6 +1882,48 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/custom-media-element": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.6.tgz",
+      "integrity": "sha512-/HRYqJOa1ob5ik4q7FIJVYxTJCFs/FL3+cQPAJjUf2uiqrDEzbTgB315gQ2rG8oK3w094W9m5tcB8S5Qah+caA==",
+      "license": "MIT"
+    },
+    "node_modules/dash-video-element": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/dash-video-element/-/dash-video-element-0.3.2.tgz",
+      "integrity": "sha512-eN1IqgtTAbq4zVkbt82BDwQtybQ6WOXyQU5HbftUSnqo+SHAPbZCif1Y7uViAhgvuEPvZtbiXDiacvvTeGxc/g==",
+      "license": "MIT",
+      "dependencies": {
+        "custom-media-element": "^1.4.6",
+        "dashjs": "^5.0.3",
+        "media-tracks": "^0.3.5"
+      }
+    },
+    "node_modules/dashjs": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dashjs/-/dashjs-5.2.0.tgz",
+      "integrity": "sha512-2W2KHFN53Sk7+rtdnIfSUK/3Oov+hraMTeVZwDOTSCNKM1cQtFiJdblNzRMnl59a/QDseG7JW+PC9mh/B+CMcg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@svta/cml-608": "1.0.2",
+        "@svta/cml-cmcd": "2.3.2",
+        "@svta/cml-cmsd": "1.0.6",
+        "@svta/cml-dash": "1.0.6",
+        "@svta/cml-id3": "1.0.6",
+        "@svta/cml-request": "1.0.12",
+        "@svta/cml-xml": "1.1.4",
+        "bcp-47-match": "^2.0.3",
+        "codem-isoboxer": "0.3.10",
+        "fast-deep-equal": "3.1.3",
+        "html-entities": "^2.6.0",
+        "imsc": "^1.1.5",
+        "localforage": "^1.10.0",
+        "path-browserify": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1665,15 +1947,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2326,6 +2599,23 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hls-video-element": {
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/hls-video-element/-/hls-video-element-1.5.11.tgz",
+      "integrity": "sha512-tJJ65/52CDxj8XFyIve6zT9nVVdUIc6mqvKR25X0ycPKHk07rpjp4xxVteeCefDUBSf/tFLhlICFmn3KWj37xA==",
+      "license": "MIT",
+      "dependencies": {
+        "custom-media-element": "^1.4.6",
+        "hls.js": "^1.6.5",
+        "media-tracks": "^0.3.5"
+      }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -2337,6 +2627,22 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/http-proxy": {
       "version": "1.18.1",
@@ -2408,6 +2714,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immer": {
       "version": "11.1.4",
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
@@ -2433,6 +2745,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imsc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/imsc/-/imsc-1.1.5.tgz",
+      "integrity": "sha512-V8je+CGkcvGhgl2C1GlhqFFiUOIEdwXbXLiu1Fcubvvbo+g9inauqT3l0pNYXGoLPBj3jxtZz9t+wCopMkwadQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "sax": "1.2.1"
       }
     },
     "node_modules/imurmurhash": {
@@ -2591,6 +2912,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -2854,11 +3184,14 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/load-script": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==",
-      "license": "MIT"
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -2927,10 +3260,25 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+    "node_modules/media-chrome": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.19.1.tgz",
+      "integrity": "sha512-1+x2l0mNulHKZN0lBxGJwJ+TV2W/KzLjaAd//UCGZz8GE5O5YNafFskWTcv/D6Ty0d9drX9SSfimOzGwob8eVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ce-la-react": "^0.3.2"
+      }
+    },
+    "node_modules/media-played-ranges-mixin": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/media-played-ranges-mixin/-/media-played-ranges-mixin-0.1.0.tgz",
+      "integrity": "sha512-zTsvkleu5sAyTsPVxDI+KUbCwy/lXwHgOPi3ER9S3lhtAWhGTQH6qxvfrVMym1cvoLU36SPbVr6Qe8Zxyc0WpA==",
+      "license": "MIT"
+    },
+    "node_modules/media-tracks": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/media-tracks/-/media-tracks-0.3.5.tgz",
+      "integrity": "sha512-l54rkKXlLBt3ob3zOLWHcnjvwUmX5bNEZ70igyapOZZC9imzqBmq1oz8p2roiV04KhjblFIi2hetLPF1oYVLRA==",
       "license": "MIT"
     },
     "node_modules/mime": {
@@ -2973,6 +3321,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mux-embed": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.18.1.tgz",
+      "integrity": "sha512-ePsHjiEKY+FgrSBiMmaF+LOtTQSSBWv/1zqpREQFN96JE93xlsArT/MEi30yKOE06MgjOlL70YI750molu3y7g==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2991,6 +3345,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==",
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -3326,6 +3686,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3364,6 +3730,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/player.style": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.3.4.tgz",
+      "integrity": "sha512-5O9bkbq0APQIkhptyZwp0gUgheCeImGPFo4hvPF2M5xBmgsUYzsUPHCfMye2xyeRE1zvQBKtziaC3jPgnHE1tw==",
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "site",
+        "examples/*",
+        "scripts/*",
+        "themes/*"
+      ],
+      "dependencies": {
+        "media-chrome": "~4.19.0"
       }
     },
     "node_modules/portfinder": {
@@ -3570,19 +3952,26 @@
       }
     },
     "node_modules/react-player": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.16.1.tgz",
-      "integrity": "sha512-mxP6CqjSWjidtyDoMOSHVPdhX0pY16aSvw5fVr44EMaT7X5Xz46uQ4b/YBm1v2x+3hHkB9PmjEEkmbHb9PXQ4w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-3.4.0.tgz",
+      "integrity": "sha512-QpQSHXtnMBKjQVNeaCYMtTVcynWQ0DDDhz/FJu1OR9PHLC1Aih94UqNstywzSHbJ6Oc7lI8/7kDDqcIvyTI6zQ==",
       "license": "MIT",
       "dependencies": {
-        "deepmerge": "^4.0.0",
-        "load-script": "^1.0.0",
-        "memoize-one": "^5.1.1",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.0.1"
+        "@mux/mux-player-react": "^3.8.0",
+        "cloudflare-video-element": "^1.3.4",
+        "dash-video-element": "^0.3.0",
+        "hls-video-element": "^1.5.9",
+        "spotify-audio-element": "^1.0.3",
+        "tiktok-video-element": "^0.1.1",
+        "twitch-video-element": "^0.1.5",
+        "vimeo-video-element": "^1.6.1",
+        "wistia-video-element": "^1.3.5",
+        "youtube-video-element": "^1.8.0"
       },
       "peerDependencies": {
-        "react": ">=16.6.0"
+        "@types/react": "^17.0.0 || ^18 || ^19",
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
       }
     },
     "node_modules/react-redux": {
@@ -3868,6 +4257,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
+      "license": "ISC"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4070,6 +4465,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spotify-audio-element": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spotify-audio-element/-/spotify-audio-element-1.0.4.tgz",
+      "integrity": "sha512-QdKrJPkYCzaNwwz2vN2eDGyoW0KmQFmnwVprB41mpMzj4qujbqr6pegEchQeTn0b5PceKiLoVu0pp2QDpTcWnw==",
+      "license": "MIT"
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -4117,6 +4518,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/super-media-element": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/super-media-element/-/super-media-element-1.4.2.tgz",
+      "integrity": "sha512-9pP/CVNp4NF2MNlRzLwQkjiTgKKe9WYXrLh9+8QokWmMxz+zt2mf1utkWLco26IuA3AfVcTb//qtlTIjY3VHxA==",
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -4188,6 +4595,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiktok-video-element": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tiktok-video-element/-/tiktok-video-element-0.1.2.tgz",
+      "integrity": "sha512-w6TboLm236XJKKiIXIhCbYCnUxbixBbaAoty0etaEAZ/2kHkVIdfZdv2oouMU/HGMsWCHI/VjQ3wU3MJ+s192Q==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4235,6 +4648,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/twitch-video-element": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/twitch-video-element/-/twitch-video-element-0.1.6.tgz",
+      "integrity": "sha512-X7l8gy+DEFKJ/EztUwaVnAYwQN9fUJxPkOVJj2sE62sGvGU4DNLyvmOsmVulM+8Plc5dMg6hYIMNRAPaH+39Uw==",
+      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4430,6 +4849,16 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/vimeo-video-element": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/vimeo-video-element/-/vimeo-video-element-1.7.2.tgz",
+      "integrity": "sha512-7QM7fvSZvTTSq4igxBuO6Gc+0u3Exgk4IaLNixVzilCPzHEf7SN8b6YLXSM5QCs0ineTJI4XjiUCSoIbabHvwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vimeo/player": "2.29.0",
+        "media-played-ranges-mixin": "^0.1.0"
+      }
+    },
     "node_modules/vite": {
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
@@ -4508,6 +4937,15 @@
         }
       }
     },
+    "node_modules/weakmap-polyfill": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/weakmap-polyfill/-/weakmap-polyfill-2.0.4.tgz",
+      "integrity": "sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -4553,6 +4991,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/wistia-video-element": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/wistia-video-element/-/wistia-video-element-1.4.0.tgz",
+      "integrity": "sha512-udI8/yiMZ+KIGwYK1qNOFiXl+s/wffiY+XkwTXlBFICZylFalOS0QYEQqYOmuBsm3jNfGUS4O50tLuN7Ejqm3A==",
+      "license": "MIT",
+      "dependencies": {
+        "super-media-element": "~1.4.2"
       }
     },
     "node_modules/word-wrap": {
@@ -4640,6 +5087,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/youtube-video-element": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/youtube-video-element/-/youtube-video-element-1.9.0.tgz",
+      "integrity": "sha512-Hh0dbQM+FVlUaYUbpYkZNUvdKxTNcSNvTGzkQKYShltnX+LRHEp2eYvC2Zm43eU8Np+CBZuoNR2i+seCYzzAyg==",
+      "license": "MIT",
+      "dependencies": {
+        "media-played-ranges-mixin": "^0.1.0"
       }
     },
     "node_modules/zod": {

--- a/client/package.json
+++ b/client/package.json
@@ -26,7 +26,7 @@
     "react-helmet-async": "^3.0.0",
     "react-hook-form": "^7.43.2",
     "react-icons": "^5.4.0",
-    "react-player": "^2.16.1",
+    "react-player": "^3.4.0",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.0.0"
   },

--- a/client/src/components/Youtube/BackgroundPlayer.tsx
+++ b/client/src/components/Youtube/BackgroundPlayer.tsx
@@ -189,8 +189,9 @@ const BackgroundPlayer = () => {
         labelAlwaysOn={true}
         value={Math.floor((videoProgress.played / videoProgress.duration) * 100)}
         onChange={(value) => {
-          if (playerRef.current) {
-            playerRef.current.seekTo(value / 100, "fraction");
+          const player = playerRef.current;
+          if (player && Number.isFinite(player.duration)) {
+            player.currentTime = (value / 100) * player.duration;
           }
         }}
       />
@@ -235,7 +236,9 @@ const BackgroundPlayer = () => {
               if (videoProgress.played < 5) {
                 recedeQueue();
               } else {
-                playerRef.current?.seekTo(0);
+                if (playerRef.current) {
+                  playerRef.current.currentTime = 0;
+                }
               }
             }}
           >

--- a/client/src/components/Youtube/BackgroundPlayer.tsx
+++ b/client/src/components/Youtube/BackgroundPlayer.tsx
@@ -17,7 +17,7 @@ import {
   Text,
   Title,
 } from "@mantine/core";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { CgPlayTrackNext, CgPlayTrackPrev } from "react-icons/cg";
 import { FaAngleUp, FaPause, FaPlay } from "react-icons/fa";
 
@@ -49,10 +49,14 @@ const BackgroundPlayer = () => {
   const [queueParams, setQueueParams] = useState(params);
   const videosStatus = useYoutubeVideosQuery(queueParams ?? skipToken);
 
-  const [videoProgress, setVideoProgress] = useState({
-    duration: 0,
-    played: 0,
-  });
+  const [duration, setDuration] = useState(0);
+  const [playedSeconds, setPlayedSeconds] = useState(0);
+  const [seekValue, setSeekValue] = useState(0);
+  const [isSeeking, setIsSeeking] = useState(false);
+  const seekingRef = useRef(false);
+
+  const sliderValue = duration > 0 ? (isSeeking ? seekValue : (playedSeconds / duration) * 100) : 0;
+  const displayedSeconds = isSeeking ? (seekValue / 100) * duration : playedSeconds;
 
   const [expand, { toggle: toggleExpand }] = useDisclosure(false);
   const { footerRef } = useFooter();
@@ -72,8 +76,53 @@ const BackgroundPlayer = () => {
   };
 
   useEffect(() => {
-    setVideoProgress({ played: 0, duration: 0 });
+    seekingRef.current = false;
+    setIsSeeking(false);
+    setDuration(0);
+    setPlayedSeconds(0);
+    setSeekValue(0);
   }, [currentVideo?.id]);
+
+  const handleDuration = useCallback((nextDuration: number) => {
+    setDuration(nextDuration);
+  }, []);
+
+  const handleProgress = useCallback((playedSeconds: number) => {
+    if (seekingRef.current) {
+      return;
+    }
+    setPlayedSeconds(playedSeconds);
+  }, []);
+
+  const handleSeekChange = useCallback(
+    (value: number) => {
+      seekingRef.current = true;
+      setIsSeeking(true);
+      setSeekValue(value);
+
+      const player = playerRef.current;
+      if (player && Number.isFinite(player.duration)) {
+        player.currentTime = (value / 100) * player.duration;
+      }
+    },
+    [playerRef]
+  );
+
+  const handleSeekChangeEnd = useCallback(
+    (value: number) => {
+      seekingRef.current = false;
+      setIsSeeking(false);
+
+      const player = playerRef.current;
+      if (player && Number.isFinite(player.duration)) {
+        const seconds = (value / 100) * player.duration;
+        player.currentTime = seconds;
+        setPlayedSeconds(seconds);
+      }
+      setSeekValue(value);
+    },
+    [playerRef]
+  );
 
   useEffect(() => {
     setQueueParams(params);
@@ -115,12 +164,8 @@ const BackgroundPlayer = () => {
                 playing={playing}
                 onPlay={() => setPlaying(true)}
                 onPause={() => setPlaying(false)}
-                onDuration={(duration) => {
-                  setVideoProgress({ ...videoProgress, duration });
-                }}
-                onProgress={(state) => {
-                  setVideoProgress({ ...videoProgress, played: state.playedSeconds });
-                }}
+                onDuration={handleDuration}
+                onProgress={(state) => handleProgress(state.playedSeconds)}
                 onEnd={() => advanceQueue()}
               />
             </Grid.Col>
@@ -181,19 +226,18 @@ const BackgroundPlayer = () => {
       <Slider
         w={{ base: "90%", md: "95%" }}
         py="lg"
+        step={0.1}
+        min={0}
+        max={100}
         marks={[
           { value: 0, label: "0:00" },
-          { value: 100, label: convertToTimeString(videoProgress.duration) },
+          { value: 100, label: convertToTimeString(duration) },
         ]}
-        label={convertToTimeString(videoProgress.played)}
+        label={convertToTimeString(displayedSeconds)}
         labelAlwaysOn={true}
-        value={Math.floor((videoProgress.played / videoProgress.duration) * 100)}
-        onChange={(value) => {
-          const player = playerRef.current;
-          if (player && Number.isFinite(player.duration)) {
-            player.currentTime = (value / 100) * player.duration;
-          }
-        }}
+        value={sliderValue}
+        onChange={handleSeekChange}
+        onChangeEnd={handleSeekChangeEnd}
       />
       {VideoPlayerOverlayPortal}
       <Group w={{ base: "90%", md: "95%" }} gap="xl" justify="center" wrap="nowrap" style={{ overflowX: "hidden" }}>
@@ -233,12 +277,14 @@ const BackgroundPlayer = () => {
             className="hover-darken"
             variant="transparent"
             onClick={() => {
-              if (videoProgress.played < 5) {
+              if (playedSeconds < 5) {
                 recedeQueue();
               } else {
                 if (playerRef.current) {
                   playerRef.current.currentTime = 0;
                 }
+                setPlayedSeconds(0);
+                setSeekValue(0);
               }
             }}
           >

--- a/client/src/components/Youtube/VideoPlayer.tsx
+++ b/client/src/components/Youtube/VideoPlayer.tsx
@@ -1,9 +1,12 @@
 import React, { forwardRef, useMemo } from "react";
-import ReactPlayer from "react-player/youtube";
-import { OnProgressProps } from "react-player/base";
+import ReactPlayer from "react-player";
 
 import { YoutubeVideoResponse as YoutubeVideo } from "../../api/generated/youtubeApi";
 import { useAddYoutubeVideoWatchMutation } from "../../api/youtube";
+
+export interface ProgressState {
+  playedSeconds: number;
+}
 
 interface VideoPlayerProps {
   video: YoutubeVideo | null | undefined;
@@ -11,7 +14,7 @@ interface VideoPlayerProps {
   onDuration?: (duration: number) => void;
   onEnd?: () => void;
   onReady?: () => void;
-  onProgress?: (state: OnProgressProps) => void;
+  onProgress?: (state: ProgressState) => void;
   onPlay?: () => void;
   onPause?: () => void;
   width?: string;
@@ -19,7 +22,7 @@ interface VideoPlayerProps {
   style?: React.CSSProperties;
 }
 
-const VideoPlayer = forwardRef<ReactPlayer, VideoPlayerProps>(
+const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
   ({ video, onDuration, onProgress, onEnd, onReady, onPlay, onPause, playing, height, width, style }, ref) => {
     const [watchVideo] = useAddYoutubeVideoWatchMutation();
 
@@ -32,7 +35,7 @@ const VideoPlayer = forwardRef<ReactPlayer, VideoPlayerProps>(
           width={width || "100%"}
           playing={playing}
           controls={true}
-          url={`https://youtube.com/embed/${video?.id}`}
+          src={video?.id ? `https://www.youtube.com/watch?v=${video.id}` : undefined}
           onPlay={() => {
             if (onPlay) {
               onPlay();
@@ -48,17 +51,19 @@ const VideoPlayer = forwardRef<ReactPlayer, VideoPlayerProps>(
               onReady();
             }
           }}
-          onDuration={(duration) => {
-            if (onDuration) {
+          onDurationChange={(event) => {
+            const duration = event.currentTarget.duration;
+            if (onDuration && Number.isFinite(duration)) {
               onDuration(duration);
             }
           }}
-          onProgress={(state) => {
+          onTimeUpdate={(event) => {
+            const playedSeconds = event.currentTarget.currentTime;
             if (video) {
               if (onProgress) {
-                onProgress(state);
+                onProgress({ playedSeconds });
               }
-              if (state.playedSeconds > 20 && video && !video.watched) {
+              if (playedSeconds > 20 && !video.watched) {
                 watchVideo(video.id);
               }
             }

--- a/client/src/providers/BackgroundPlayerProvider.tsx
+++ b/client/src/providers/BackgroundPlayerProvider.tsx
@@ -15,7 +15,6 @@ import { GetYoutubeVideosApiYoutubeVideosListGetApiArg as YoutubeVideosParams } 
 import { useFooter } from "./FooterProvider";
 import { YoutubeVideoResponse as YoutubeVideo } from "../api/generated/youtubeApi";
 import { useYoutubeVideosQuery } from "../api/youtube";
-import ReactPlayer from "react-player/youtube";
 
 interface BackgroundPlayerContextType {
   addVideoToQueue: ({ index, params }: { index: number; params: YoutubeVideosParams }) => void;
@@ -29,7 +28,7 @@ interface BackgroundPlayerContextType {
   setPlaying: (playing: boolean) => void;
   setShowPlayer: (show: boolean) => void;
   showPlayer: boolean;
-  playerRef: RefObject<ReactPlayer | null>;
+  playerRef: RefObject<HTMLVideoElement | null>;
 }
 
 const BackgroundPlayerContext = createContext<BackgroundPlayerContextType | undefined>(undefined);
@@ -40,7 +39,7 @@ export const BackgroundPlayerProvider = ({ children }: { children: ReactNode }) 
   const [currentVideoIndex, setCurrentVideoIndex] = useState(0);
   const [params, setParams] = useState<YoutubeVideosParams>();
   const [showPlayer, setShowPlayer] = useState(false);
-  const playerRef = useRef<ReactPlayer | null>(null);
+  const playerRef = useRef<HTMLVideoElement | null>(null);
   const [playing, setPlaying] = useState(false);
 
   const videosStatus = useYoutubeVideosQuery(params ?? skipToken);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Renovate react-player v3 upgrade by rebasing on `main` and migrating the YouTube player code to the v3 API.

The existing `renovate/react-player-3.x` branch only bumped the dependency; the app still imported `react-player/youtube` and used v2 props (`url`, `onDuration`, `seekTo`, etc.), which breaks the client build.

## Changes

- Bump `react-player` from v2 to v3 in `client/package.json`
- Import from `react-player` (v3 no longer exposes per-provider entry points)
- Replace `url` with `src` and use standard YouTube watch URLs
- Use `HTMLVideoElement` refs instead of `ReactPlayer` instance refs
- Map callbacks to v3/native events: `onDurationChange`, `onTimeUpdate`, `onEnded`
- Replace `seekTo()` with `currentTime` assignment for scrubbing and restart

## Testing

- `npm run build` in `client/` passes (TypeScript + Vite)

## Notes

This supersedes/closes the broken Renovate PR for react-player v3. You can close `renovate/react-player-3.x` in favor of this branch once merged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a127e89b-642c-40e8-8ce1-17e8b1ef00f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a127e89b-642c-40e8-8ce1-17e8b1ef00f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

