### PR TITLE
Group ESLint major and minor updates in a single Renovate PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,9 @@
     },
     {
       "matchPackagePatterns": ["^eslint"],
-      "groupName": "eslint"
+      "groupName": "eslint",
+      "groupSlug": "eslint",
+      "separateMajorMinor": false
     },
     {
       "matchPackageNames": ["lodash", "@types/lodash"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Renovate already had an `eslint` group for packages matching `^eslint`, but the default `separateMajorMinor` behavior still split major bumps into their own PR (e.g. `renovate/major-eslint`) while plugin patches landed on `renovate/eslint`.

## Changes

- Set `separateMajorMinor: false` on the eslint group so major and minor/patch updates are combined
- Set `groupSlug: "eslint"` for a consistent branch name (`renovate/eslint`)

This ensures future ESLint core and plugin updates (e.g. `eslint` v10 + `eslint-plugin-react-hooks` v7.1.x) arrive in a single PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4139afce-c200-44e5-9ec0-0e86394b4bf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4139afce-c200-44e5-9ec0-0e86394b4bf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

