### PR TITLE
Add Kanidm compose setup without s6-overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ tmp
 temp
 .temp.env
 *.sql
+
+kanidm/data/*
+!kanidm/data/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -62,3 +62,20 @@ server: migrate
 .PHONY: worker
 worker: migrate
 	celery -A app.tasks.app beat --loglevel=info --detach && celery -A app.tasks.app worker -c $$WORKERS --loglevel=info
+
+.PHONY: kanidm-init
+kanidm-init:
+	mkdir -p kanidm/data
+	cp -n kanidm/server.toml kanidm/data/server.toml
+
+.PHONY: kanidm-configtest
+kanidm-configtest: kanidm-init
+	docker compose -f kanidm/docker-compose.yml run --rm kanidm /sbin/kanidmd configtest
+
+.PHONY: kanidm-up
+kanidm-up: kanidm-init
+	docker compose -f kanidm/docker-compose.yml up -d
+
+.PHONY: kanidm-down
+kanidm-down:
+	docker compose -f kanidm/docker-compose.yml down

--- a/kanidm/docker-compose.yml
+++ b/kanidm/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  kanidm:
+    image: kanidm/server:latest
+    container_name: kanidm
+    restart: unless-stopped
+    ports:
+      - "8443:8443"
+    volumes:
+      - ./data:/data
+    command: ["/sbin/kanidmd", "server"]

--- a/kanidm/server.toml
+++ b/kanidm/server.toml
@@ -1,0 +1,14 @@
+version = "2"
+
+bindaddress = "0.0.0.0:8443"
+db_path = "/data/kanidm.db"
+
+tls_chain = "/data/chain.pem"
+tls_key = "/data/key.pem"
+
+domain = "localhost"
+origin = "https://localhost:8443"
+
+[online_backup]
+path = "/data/kanidm/backups/"
+schedule = "00 22 * * *"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a minimal Kanidm deployment using the official `kanidm/server` image — no custom Dockerfile and no s6-overlay.

- `kanidm/docker-compose.yml` runs `/sbin/kanidmd server` directly
- `kanidm/server.toml` provides a container-ready config template
- Makefile targets for init, config test, and start/stop
- Runtime data under `kanidm/data/` is gitignored

## Usage

1. Edit `kanidm/server.toml` (`domain`, `origin`) for your environment
2. `make kanidm-init`
3. Manually generate TLS certs (see PR description / deployment notes)
4. `make kanidm-configtest`
5. `make kanidm-up`

## Test plan

- [ ] `make kanidm-init` copies config into `kanidm/data/`
- [ ] After manual cert generation, `make kanidm-configtest` passes
- [ ] `make kanidm-up` starts the container on port 8443
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0de93b7-771d-4e4f-845a-0fd9e347e7f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0de93b7-771d-4e4f-845a-0fd9e347e7f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

