### PR TITLE
Fix flaky get user subscriptions test

### DIFF
--- a/tests/routes/youtube/test_get_youtube_subscriptions.py
+++ b/tests/routes/youtube/test_get_youtube_subscriptions.py
@@ -17,7 +17,12 @@ async def test_get_user_subscription_when_not_logged_in(client):
 
 
 async def test_get_user_subscriptions(
-    client, create_and_login_user, create_user, create_youtube_subscription, db_session
+    client,
+    create_and_login_user,
+    create_user,
+    create_youtube_subscription,
+    create_youtube_channel,
+    db_session,
 ):
     """
     Test get user subscription. The endpoint should return a 200 status
@@ -30,9 +35,18 @@ async def test_get_user_subscriptions(
     user_subscriptions: list[YoutubeSubscription] = []
 
     for i in range(10):
-        user_subscriptions.append(await create_youtube_subscription(email=user.email))
-        await create_youtube_subscription(email=user.email, deleted=True)
-        await create_youtube_subscription(email=other_user.email)
+        channel = await create_youtube_channel(title=f"channel-{i:02d}")
+        user_subscriptions.append(
+            await create_youtube_subscription(email=user.email, channel_id=channel.id)
+        )
+        deleted_channel = await create_youtube_channel(title=f"deleted-{i:02d}")
+        await create_youtube_subscription(
+            email=user.email, channel_id=deleted_channel.id, deleted=True
+        )
+        other_channel = await create_youtube_channel(title=f"other-{i:02d}")
+        await create_youtube_subscription(
+            email=other_user.email, channel_id=other_channel.id
+        )
 
     channels = await db_session.scalars(
         select(YoutubeChannel).where(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `test_get_user_subscriptions` test was flaky because it created 30 YouTube channels with random `faker.word()` titles. With ~39% of runs producing duplicate titles, the API's `ORDER BY YoutubeChannel.title` could return channels in a different order than the test's expected sorted list.

## Fix

Create channels with deterministic titles (`channel-00`, `deleted-00`, `other-00`, etc.) so ordering is stable and the assertion is reliable.

## Testing

Ran `test_get_user_subscriptions` 30 times locally — all passed after the fix (previously reproduced failures within the first few runs).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cc70b56-9c11-4728-b5cf-d4b9e7597f36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cc70b56-9c11-4728-b5cf-d4b9e7597f36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

