### PR TITLE
Make cookies textarea scrollable and auto-play background videos

### DIFF
--- a/client/src/pages/Auth/Account.tsx
+++ b/client/src/pages/Auth/Account.tsx
@@ -128,6 +128,7 @@ const Account = () => {
                 value={cookies}
                 onChange={(e) => setCookies(e.target.value)}
                 minRows={10}
+                maxRows={15}
                 autosize
                 withAsterisk
                 styles={{ input: { fontFamily: "monospace" } }}

--- a/client/src/providers/BackgroundPlayerProvider.tsx
+++ b/client/src/providers/BackgroundPlayerProvider.tsx
@@ -47,6 +47,7 @@ export const BackgroundPlayerProvider = ({ children }: { children: ReactNode }) 
   const addVideoToQueue = useCallback(({ index, params }: { index: number; params: YoutubeVideosParams }) => {
     setCurrentVideoIndex(index);
     setParams(params);
+    setPlaying(true);
   }, []);
 
   const currentVideo = useMemo(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Cookies textarea:** Added `maxRows={15}` so the field stops growing after 15 lines and scrolls internally instead of stretching the whole page.
- **Background player:** `addVideoToQueue` now sets `playing` to `true`, so videos start automatically when you click "Play in Background" or pick one from the Up Next list.

## Why background videos weren't auto-playing

`addVideoToQueue` only updated the queue index and query params. The `playing` state defaulted to `false` and was never set on enqueue — playback only started when the user pressed the footer play button or used the player controls.

## Test plan

- [ ] Open Account → Cookies tab and paste a long cookies.txt file; verify the textarea scrolls inside the field
- [ ] Click "Play in Background" on a video and confirm playback starts without pressing play again
- [ ] Select a different video from the Up Next list and confirm it starts playing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc648179-491e-4686-ad7c-a12ebbb9601e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc648179-491e-4686-ad7c-a12ebbb9601e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

