### PR TITLE
Use React Player YouTube playlists for background queue playback

### DIFF
--- a/client/src/components/Youtube/BackgroundPlayer.tsx
+++ b/client/src/components/Youtube/BackgroundPlayer.tsx
@@ -32,12 +32,15 @@ import { useBackgroundPlayer } from "../../providers/BackgroundPlayerProvider";
 import { MdClose } from "react-icons/md";
 import { useYoutubeVideosQuery } from "../../api/youtube";
 import { skipToken } from "@reduxjs/toolkit/query";
+import { getYoutubePlayerApi } from "../../utils/youtubePlayer";
 
 const BackgroundPlayer = () => {
   const {
     addVideoToQueue,
     currentVideo,
+    currentVideoIndex,
     advanceQueue,
+    goToVideoIndex,
     params,
     playing,
     playerRef,
@@ -161,11 +164,14 @@ const BackgroundPlayer = () => {
               <VideoPlayer
                 ref={playerRef}
                 video={currentVideo}
+                playlist={videosStatus.currentData?.videos}
+                playlistIndex={currentVideoIndex}
                 playing={playing}
                 onPlay={() => setPlaying(true)}
                 onPause={() => setPlaying(false)}
                 onDuration={handleDuration}
                 onProgress={(state) => handleProgress(state.playedSeconds)}
+                onActiveVideoChange={goToVideoIndex}
                 onEnd={() => advanceQueue()}
               />
             </Grid.Col>
@@ -277,11 +283,19 @@ const BackgroundPlayer = () => {
             className="hover-darken"
             variant="transparent"
             onClick={() => {
+              const player = playerRef.current;
+              const api = getYoutubePlayerApi(player);
+              const pageVideos = videosStatus.currentData?.videos;
+
               if (playedSeconds < 5) {
-                recedeQueue();
+                if (api && pageVideos && currentVideoIndex > 0) {
+                  api.previousVideo();
+                } else {
+                  recedeQueue();
+                }
               } else {
-                if (playerRef.current) {
-                  playerRef.current.currentTime = 0;
+                if (player) {
+                  player.currentTime = 0;
                 }
                 setPlayedSeconds(0);
                 setSeekValue(0);
@@ -293,7 +307,20 @@ const BackgroundPlayer = () => {
           <ActionIcon className="hover-darken" variant="transparent" onClick={() => setPlaying(!playing)}>
             {playing ? <FaPause /> : <FaPlay />}
           </ActionIcon>
-          <ActionIcon className="hover-darken" variant="transparent" onClick={advanceQueue}>
+          <ActionIcon
+            className="hover-darken"
+            variant="transparent"
+            onClick={() => {
+              const api = getYoutubePlayerApi(playerRef.current);
+              const pageVideos = videosStatus.currentData?.videos;
+
+              if (api && pageVideos && currentVideoIndex < pageVideos.length - 1) {
+                api.nextVideo();
+              } else {
+                advanceQueue();
+              }
+            }}
+          >
             <CgPlayTrackNext size={25} />
           </ActionIcon>
           <ActionIcon className="hover-darken" variant="transparent" onClick={toggleExpand}>

--- a/client/src/components/Youtube/VideoPlayer.tsx
+++ b/client/src/components/Youtube/VideoPlayer.tsx
@@ -1,8 +1,9 @@
-import React, { forwardRef, useMemo } from "react";
+import React, { forwardRef, useCallback, useEffect, useMemo, useRef } from "react";
 import ReactPlayer from "react-player";
 
 import { YoutubeVideoResponse as YoutubeVideo } from "../../api/generated/youtubeApi";
 import { useAddYoutubeVideoWatchMutation } from "../../api/youtube";
+import { buildYoutubePlaylistConfig, buildYoutubeWatchUrl, getYoutubePlayerApi } from "../../utils/youtubePlayer";
 
 export interface ProgressState {
   playedSeconds: number;
@@ -10,6 +11,8 @@ export interface ProgressState {
 
 interface VideoPlayerProps {
   video: YoutubeVideo | null | undefined;
+  playlist?: YoutubeVideo[];
+  playlistIndex?: number;
   playing?: boolean;
   onDuration?: (duration: number) => void;
   onEnd?: () => void;
@@ -17,40 +20,166 @@ interface VideoPlayerProps {
   onProgress?: (state: ProgressState) => void;
   onPlay?: () => void;
   onPause?: () => void;
+  onActiveVideoChange?: (index: number) => void;
   width?: string;
   height?: string;
   style?: React.CSSProperties;
 }
 
 const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
-  ({ video, onDuration, onProgress, onEnd, onReady, onPlay, onPause, playing, height, width, style }, ref) => {
+  (
+    {
+      video,
+      playlist,
+      playlistIndex = 0,
+      onDuration,
+      onProgress,
+      onEnd,
+      onReady,
+      onPlay,
+      onPause,
+      onActiveVideoChange,
+      playing,
+      height,
+      width,
+      style,
+    },
+    ref
+  ) => {
     const [watchVideo] = useAddYoutubeVideoWatchMutation();
+    const lastPlaylistIndexRef = useRef(playlistIndex);
+    const activeVideoRef = useRef<YoutubeVideo | null | undefined>(video);
+
+    const playlistVideos = useMemo(() => playlist ?? (video ? [video] : []), [playlist, video]);
+    const playlistIds = useMemo(() => playlistVideos.map((playlistVideo) => playlistVideo.id), [playlistVideos]);
+    const usePlaylist = playlistIds.length > 1;
+
+    const src = useMemo(() => {
+      if (!playlistIds.length) {
+        return undefined;
+      }
+
+      const startIndex = usePlaylist ? 0 : Math.min(playlistIndex, playlistIds.length - 1);
+      return buildYoutubeWatchUrl(playlistIds[startIndex]);
+    }, [playlistIds, playlistIndex, usePlaylist]);
+
+    const config = useMemo(() => buildYoutubePlaylistConfig(playlistIds), [playlistIds]);
+
+    const resolveActiveVideo = useCallback(
+      (player: HTMLVideoElement | null) => {
+        if (!playlistVideos.length) {
+          activeVideoRef.current = video;
+          return video;
+        }
+
+        const api = getYoutubePlayerApi(player);
+        const videoId = api?.getVideoData()?.video_id;
+        const index = api?.getPlaylistIndex();
+
+        if (videoId) {
+          const matchedVideo = playlistVideos.find((playlistVideo) => playlistVideo.id === videoId);
+          if (matchedVideo) {
+            activeVideoRef.current = matchedVideo;
+            return matchedVideo;
+          }
+        }
+
+        if (index != null && playlistVideos[index]) {
+          activeVideoRef.current = playlistVideos[index];
+          return playlistVideos[index];
+        }
+
+        activeVideoRef.current = video;
+        return video;
+      },
+      [playlistVideos, video]
+    );
+
+    const syncPlaylistIndex = useCallback(
+      (player: HTMLVideoElement | null) => {
+        const api = getYoutubePlayerApi(player);
+        if (!api || !usePlaylist) {
+          return;
+        }
+
+        const index = api.getPlaylistIndex();
+        if (index === lastPlaylistIndexRef.current) {
+          return;
+        }
+
+        lastPlaylistIndexRef.current = index;
+        onActiveVideoChange?.(index);
+        resolveActiveVideo(player);
+      },
+      [onActiveVideoChange, resolveActiveVideo, usePlaylist]
+    );
+
+    const seekToPlaylistIndex = useCallback(
+      (player: HTMLVideoElement | null, index: number) => {
+        const api = getYoutubePlayerApi(player);
+        if (!api || !usePlaylist || index === api.getPlaylistIndex()) {
+          return;
+        }
+
+        api.playVideoAt(index);
+        lastPlaylistIndexRef.current = index;
+      },
+      [usePlaylist]
+    );
+
+    useEffect(() => {
+      activeVideoRef.current = video;
+      lastPlaylistIndexRef.current = playlistIndex;
+    }, [video?.id, playlistIndex]);
+
+    useEffect(() => {
+      const player = typeof ref === "function" ? null : ref?.current;
+      if (!player || !usePlaylist) {
+        return;
+      }
+
+      seekToPlaylistIndex(player, playlistIndex);
+    }, [playlistIndex, ref, seekToPlaylistIndex, usePlaylist]);
+
+    const handleReady = useCallback(() => {
+      const player = typeof ref === "function" ? null : ref?.current;
+      if (player) {
+        seekToPlaylistIndex(player, playlistIndex);
+        resolveActiveVideo(player);
+      }
+
+      onReady?.();
+    }, [onReady, playlistIndex, ref, resolveActiveVideo, seekToPlaylistIndex]);
+
+    const handlePlaying = useCallback(() => {
+      const player = typeof ref === "function" ? null : ref?.current;
+      if (player) {
+        syncPlaylistIndex(player);
+        resolveActiveVideo(player);
+      }
+    }, [ref, resolveActiveVideo, syncPlaylistIndex]);
 
     return useMemo(
       () => (
         <ReactPlayer
+          key={playlistIds.join(",")}
           ref={ref}
           style={style}
           height={height || "100%"}
           width={width || "100%"}
           playing={playing}
           controls={true}
-          src={video?.id ? `https://www.youtube.com/watch?v=${video.id}` : undefined}
+          src={src}
+          config={config}
           onPlay={() => {
-            if (onPlay) {
-              onPlay();
-            }
+            onPlay?.();
+            handlePlaying();
           }}
           onPause={() => {
-            if (onPause) {
-              onPause();
-            }
+            onPause?.();
           }}
-          onReady={() => {
-            if (onReady) {
-              onReady();
-            }
-          }}
+          onReady={handleReady}
+          onPlaying={handlePlaying}
           onDurationChange={(event) => {
             const duration = event.currentTarget.duration;
             if (onDuration && Number.isFinite(duration)) {
@@ -59,23 +188,47 @@ const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           }}
           onTimeUpdate={(event) => {
             const playedSeconds = event.currentTarget.currentTime;
-            if (video) {
-              if (onProgress) {
-                onProgress({ playedSeconds });
-              }
-              if (playedSeconds > 20 && !video.watched) {
-                watchVideo(video.id);
+            const activeVideo = resolveActiveVideo(event.currentTarget);
+
+            if (activeVideo) {
+              onProgress?.({ playedSeconds });
+
+              if (playedSeconds > 20 && !activeVideo.watched) {
+                watchVideo(activeVideo.id);
               }
             }
           }}
-          onEnded={() => {
-            if (onEnd) {
-              onEnd();
+          onEnded={(event) => {
+            const api = getYoutubePlayerApi(event.currentTarget);
+            const index = api?.getPlaylistIndex() ?? playlistIndex;
+
+            if (!usePlaylist || index >= playlistIds.length - 1) {
+              onEnd?.();
             }
           }}
         />
       ),
-      [ref, style, width, height, playing, video, onPlay, onPause, onReady, onDuration, onProgress, watchVideo, onEnd]
+      [
+        config,
+        handlePlaying,
+        handleReady,
+        height,
+        onDuration,
+        onEnd,
+        onPause,
+        onPlay,
+        onProgress,
+        playlistIds,
+        playlistIndex,
+        playing,
+        ref,
+        resolveActiveVideo,
+        src,
+        style,
+        usePlaylist,
+        watchVideo,
+        width,
+      ]
     );
   }
 );

--- a/client/src/providers/BackgroundPlayerProvider.tsx
+++ b/client/src/providers/BackgroundPlayerProvider.tsx
@@ -22,6 +22,8 @@ interface BackgroundPlayerContextType {
   canAdvanceQueue: boolean;
   canRecedeQueue: boolean;
   currentVideo?: YoutubeVideo;
+  currentVideoIndex: number;
+  goToVideoIndex: (index: number) => void;
   params?: YoutubeVideosParams;
   playing: boolean;
   recedeQueue: () => void;
@@ -48,6 +50,10 @@ export const BackgroundPlayerProvider = ({ children }: { children: ReactNode }) 
     setCurrentVideoIndex(index);
     setParams(params);
     setPlaying(true);
+  }, []);
+
+  const goToVideoIndex = useCallback((index: number) => {
+    setCurrentVideoIndex(index);
   }, []);
 
   const currentVideo = useMemo(
@@ -78,14 +84,14 @@ export const BackgroundPlayerProvider = ({ children }: { children: ReactNode }) 
 
   const canRecedeQueue = useMemo(() => {
     if (params) {
-      return currentVideoIndex - 1 > 0 || params.page > 1;
+      return currentVideoIndex > 0 || params.page > 1;
     }
     return false;
   }, [currentVideoIndex, params]);
 
   const recedeQueue = useCallback(() => {
     if (canRecedeQueue && videosStatus.currentData && params) {
-      if (currentVideoIndex - 1 > 0) {
+      if (currentVideoIndex > 0) {
         setCurrentVideoIndex(currentVideoIndex - 1);
       } else if (params.page > 1) {
         setParams({ ...params, page: params.page - 1 });
@@ -106,6 +112,8 @@ export const BackgroundPlayerProvider = ({ children }: { children: ReactNode }) 
         canAdvanceQueue,
         canRecedeQueue,
         currentVideo,
+        currentVideoIndex,
+        goToVideoIndex,
         params,
         playing,
         playerRef,

--- a/client/src/utils/youtubePlayer.ts
+++ b/client/src/utils/youtubePlayer.ts
@@ -1,0 +1,28 @@
+export interface YoutubePlayerApi {
+  getPlaylistIndex: () => number;
+  getVideoData: () => { video_id: string };
+  nextVideo: () => void;
+  previousVideo: () => void;
+  playVideoAt: (index: number) => void;
+}
+
+interface YoutubePlayerElement extends HTMLVideoElement {
+  api?: YoutubePlayerApi;
+}
+
+export const getYoutubePlayerApi = (player: HTMLVideoElement | null): YoutubePlayerApi | undefined =>
+  (player as YoutubePlayerElement | null)?.api;
+
+export const buildYoutubeWatchUrl = (videoId: string) => `https://www.youtube.com/watch?v=${videoId}`;
+
+export const buildYoutubePlaylistConfig = (videoIds: string[]) => {
+  if (videoIds.length <= 1) {
+    return undefined;
+  }
+
+  return {
+    youtube: {
+      playlist: videoIds.slice(1).join(","),
+    },
+  };
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Pass the current page of background-queue videos to ReactPlayer using YouTube's native playlist support (`config.youtube.playlist`) instead of reloading the player for every video on the same page
- Sync the active queue index from the player as playlist items change, and use `nextVideo` / `previousVideo` for track controls within a page
- Only advance to the next page after the last playlist item ends, and fix queue recede logic so index `0` is reachable

## Context

After upgrading to react-player v3, the background player still advanced the queue by swapping a single `src` per video. react-player v3 delegates YouTube playback to `youtube-video-element`, which supports playlist URLs and the `playlist` player parameter for custom multi-video queues.

## Test plan

- [x] `npm run build` in `client/`
- [ ] Queue multiple videos from a page and confirm they play through without reloading between items
- [ ] Use next/previous controls within a page and confirm the active video metadata updates
- [ ] Confirm playback advances to the next page after the last video on the current page ends
- [ ] Confirm single-video playback on the video detail page is unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7761ae06-b9bb-44b5-88b6-35978e65c23b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7761ae06-b9bb-44b5-88b6-35978e65c23b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

