### PR TITLE
Fix background player not auto-playing next queue track

### DIFF
--- a/client/src/providers/BackgroundPlayerProvider.tsx
+++ b/client/src/providers/BackgroundPlayerProvider.tsx
@@ -73,6 +73,9 @@ export const BackgroundPlayerProvider = ({ children }: { children: ReactNode }) 
         setParams({ ...params, page: params.page + 1 });
         setCurrentVideoIndex(0);
       }
+      // Restore playback after advancing. react-player fires onPause before onEnded
+      // when a video finishes, which clears playing before we load the next track.
+      setPlaying(true);
     }
   }, [canAdvanceQueue, currentVideoIndex, params, videosStatus.currentData]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After the react-player v3 upgrade, the background player stops auto-advancing to the next track in the queue when a video finishes.

## Root cause

When a video ends, react-player fires `onPause` immediately before `onEnded`. The background player wires those handlers like this:

- `onPause` → `setPlaying(false)`
- `onEnd` → `advanceQueue()`

So by the time the queue advances to the next video, `playing` is already `false`, and the new track loads paused. A prior fix (`setPlaying(true)` in `addVideoToQueue`) addressed starting the first track, but not advancing after a track ends.

## Fix

Call `setPlaying(true)` inside `advanceQueue()` so the next track resumes playback after auto-advance (and when using the skip-forward button).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fa6d428-79d1-4026-bbf0-b75eb1ae5f0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fa6d428-79d1-4026-bbf0-b75eb1ae5f0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

